### PR TITLE
add GITHUB_TOKEN ENV variable to github API calls if it exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push: {}
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push: {}
   pull_request:
     branches: [ main ]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/source/private/GetGitHubRelease.ps1
+++ b/source/private/GetGitHubRelease.ps1
@@ -8,7 +8,6 @@ function GetGitHubRelease {
 
         [string]$Tag = 'latest'
     )
-
     Write-Debug "Org: $Org, Repo: $Repo, Tag: $Tag"
 
     # Handle the Org parameter being a org/repo/version or the full URL to a project or release
@@ -49,10 +48,17 @@ function GetGitHubRelease {
 
     Write-Verbose "Checking GitHub $Org/$Repo for '$Tag'"
 
+    $headers = @{
+        Accept     = 'application/vnd.github.v3+json'
+    }
+    if( $env:GITHUB_TOKEN ) {
+        $headers.Authorization = "bearer $($Env:GITHUB_TOKEN)"
+    }
+
     $Result = if ($Tag -eq 'latest') {
-        Invoke-RestMethod "https://api.github.com/repos/$Org/$Repo/releases/$Tag" -Headers @{Accept = 'application/json' } -Verbose:$false
+        Invoke-RestMethod "https://api.github.com/repos/$Org/$Repo/releases/$Tag" -Headers $headers -Verbose:$false
     } else {
-        Invoke-RestMethod "https://api.github.com/repos/$Org/$Repo/releases/tags/$Tag" -Headers @{Accept = 'application/json' } -Verbose:$false
+        Invoke-RestMethod "https://api.github.com/repos/$Org/$Repo/releases/tags/$Tag" -Headers $headers -Verbose:$false
     }
 
     Write-Verbose "found release $($Result.tag_name) for $Org/$Repo"

--- a/source/public/Test-FileHash.ps1
+++ b/source/public/Test-FileHash.ps1
@@ -26,7 +26,11 @@ function Test-FileHash {
             # If Checksum is a URL, fetch the checksum(s) from the URL
             if ($Check -match "https?://") {
                 Write-Debug "Checksum is a URL: $Check"
-                Invoke-RestMethod $Check
+                if($Env:GITHUB_TOKEN) {
+                    Invoke-RestMethod $Check -Headers @{ Authorization = "Bearer $($Env:GITHUB_TOKEN)" }
+                } else {
+                    Invoke-RestMethod $Check
+                }
             } elseif (Test-Path $Check) {
                 Write-Debug "Checksum is a file: $Check"
                 Get-Content $Check


### PR DESCRIPTION
support passing a github token as an ENV variable for requests to github API

this resolves a lot of issues with API request limits. which top out at ~60/min for anonymous access. 

with ANY api key, it tops out at 5,000+ 